### PR TITLE
Build with npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/
 
 COPY package.json /app/
 
-RUN npm install
+RUN npm ci
 
 COPY . /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:16-alpine
 WORKDIR /app/
 
 COPY package.json /app/
+COPY package-lock.json /app/
 
 RUN npm ci
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.8-alpine
+FROM node:16-alpine
 
 WORKDIR /app/
 


### PR DESCRIPTION
`npm install` can modify the lock file. `npm ci` is safer since it errors if the package file and lock file don’t match.

Update the Dockerfile to build with Node 16. 