### PR TITLE
Revert "Build with npm ci"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:16-alpine
+FROM node:4.8-alpine
 
 WORKDIR /app/
 
 COPY package.json /app/
 COPY package-lock.json /app/
 
-RUN npm ci
+RUN npm install
 
 COPY . /app/
 


### PR DESCRIPTION
Reverts zooniverse/email-verify#22

See Slack convo: https://zooniverse.slack.com/archives/C8MUGEB7V/p1672950347640169?thread_ts=1672736914.967839&cid=C8MUGEB7V

Unfortunately, even though the upgrade to node 16 does not technically crash the service. I do believe that the service did break since expected logs did not show up when viewing logs of running pod. (Currently looking into why..)