### PR TITLE
Pause db updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,9 +52,12 @@ var sns_client = SNSClient(auth, function (err, message) {
   if (!!email) {
     // https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#bounce-types
     if (report.notificationType === 'Complaint' || report.bounce.bounceType == 'Permanent') {
-      pg_pool.connect(function (err, client, done) {
-        updatePanoptes(err, client, done, email, report);
-      });
+      console.log("Unsubscribed " + email + "(" + report.notificationType + "); changed 0 rows");
+
+      // Temporarily pause db updates
+      // pg_pool.connect(function (err, client, done) {
+        // updatePanoptes(err, client, done, email, report);
+      // });
     } else {
       console.log("Ignoring non-permanent bounce for", email);
     }
@@ -67,7 +70,7 @@ var app = express();
 app.get('/', function (req, res) {
   res.status(200).end();
 });
-  
+
 
 app.post('/unsub', sns_client);
 

--- a/server.js
+++ b/server.js
@@ -54,7 +54,7 @@ var sns_client = SNSClient(auth, function (err, message) {
     if (report.notificationType === 'Complaint' || report.bounce.bounceType == 'Permanent') {
       console.log("Unsubscribed " + email + "(" + report.notificationType + "); changed 0 rows");
 
-      // Temporarily pause db updates
+    // Temporarily pause db updates
       // pg_pool.connect(function (err, client, done) {
         // updatePanoptes(err, client, done, email, report);
       // });


### PR DESCRIPTION
Listmonk may be issuing bounces for valid emails due to SES interactions. This PR pauses DB updates for bounces coming from LM through SES/SNS. Addresses on our announce list will very likely already have been sent at least one, giving this process a chance to invalidate them already. App logs are kept for comparison against the LM logs. 

This is for testing purposes and will be reverted.